### PR TITLE
add a right margin to the left-pointing arrow of the search component…

### DIFF
--- a/docs/styles/header.css
+++ b/docs/styles/header.css
@@ -150,7 +150,7 @@ ul {
 }
 
 #search > :first-child {
-	padding-right: calc(var(--spacing-medium) + var(--spacing-small));
+	margin-right: var(--spacing-medium);
 }
 
 #search,


### PR DESCRIPTION
… instead of padding, as it made an ugly/inconsistent backgound when active