### PR TITLE
Speed up menu curtain transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
 # Hatzalah
-In the project root directory, run:
-<code>npm install</code>
+In the project root directory, run: `npm install`
 
-To build the distribution files, run:
-<code>npm run build</code>
+To build the distribution files, run: `npm run build`
 
-To start the development server, run:
-<code>npm run start</code>
+To start the development server, run: `npm run start`
 
-Alternatively, building the files and starting the development server can be done in one command by running:
-<code>npm run dev-serve</code>
+Alternatively, building the files and starting the development server can be done in one command by running: `npm run dev-serve`
 
-The server port can be changed by changing devServer.port in webpack.config.js to the desired port
+The server port can be changed by changing `devServer.port` in webpack.config.js to the desired port

--- a/docs/styles/header.css
+++ b/docs/styles/header.css
@@ -43,7 +43,7 @@ header {
 	background-color: white;
 	width: 100%;
 	transition-property: opacity;
-	transition-duration:  .5s;
+	transition-duration:  .15s;
 	padding: var(--spacing-small);
 	padding-left: 50px; /* 50px for hamburger button */
 }
@@ -63,8 +63,7 @@ header {
 	left: -80%;
 	bottom: 0;
 	transition-property: left;
-	transition-delay: .125s;
-	transition-duration: .5s;
+	transition-duration: .15s;
 	background-color: white;
 	padding: calc(var(--spacing-small) + 50px) var(--spacing-medium); /* 50px for hamburger button */
 }

--- a/docs/styles/header.css
+++ b/docs/styles/header.css
@@ -43,7 +43,7 @@ header {
 	background-color: white;
 	width: 100%;
 	transition-property: opacity;
-	transition-duration:  .15s;
+	transition-duration:  0.25s;
 	padding: var(--spacing-small);
 	padding-left: 50px; /* 50px for hamburger button */
 }
@@ -63,7 +63,7 @@ header {
 	left: -80%;
 	bottom: 0;
 	transition-property: left;
-	transition-duration: .15s;
+	transition-duration: 0.25s;
 	background-color: white;
 	padding: calc(var(--spacing-small) + 50px) var(--spacing-medium); /* 50px for hamburger button */
 }


### PR DESCRIPTION
Pro tip: transitions should be short – it makes it look way more responsive. The purpose is to give the user enough context as to what just happened, but not taking too much time to delay their movement and speed. Over the years, I've found 0.15 seconds to generally be the sweet spot for almost every instance, including here.